### PR TITLE
ros_noetic_sstn3_test_02: 0.0.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -240,6 +240,17 @@ repositories:
       url: https://github.com/sstn3-ca/ros_noetic_sstn3_test_01-release.git
       version: 0.0.3-1
     status: maintained
+  ros_noetic_sstn3_test_02:
+    doc:
+      type: git
+      url: https://github.com/sstn3-ca/ros_noetic_sstn3_test_02.git
+      version: 0.0.5
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/sstn3-ca/ros_noetic_sstn3_test_02-release.git
+      version: 0.0.5-1
+    status: maintained
   rosconsole:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_noetic_sstn3_test_02` to `0.0.5-1`:

- upstream repository: https://github.com/sstn3-ca/ros_noetic_sstn3_test_02.git
- release repository: https://github.com/sstn3-ca/ros_noetic_sstn3_test_02-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
