### PR TITLE
ros_noetic_sstn3_test_01: 0.0.3-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -238,7 +238,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/sstn3-ca/ros_noetic_sstn3_test_01-release.git
-      version: 0.0.3-1
+      version: 0.0.3-2
     status: maintained
   ros_noetic_sstn3_test_02:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_noetic_sstn3_test_01` to `0.0.3-2`:

- upstream repository: https://github.com/sstn3-ca/ros_noetic_sstn3_test_01.git
- release repository: https://github.com/sstn3-ca/ros_noetic_sstn3_test_01-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.3-1`
