### PR TITLE
ros_foxy_sstn3_test_004: 0.0.3-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -185,6 +185,13 @@ repositories:
       url: https://github.com/sstn3-ca/ros_foxy_sstn3_test_003-release.git
       version: 0.0.4-1
     status: maintained
+  ros_foxy_sstn3_test_004:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/sstn3-ca/ros_foxy_sstn3_test_004-release.git
+      version: 0.0.3-2
+    status: maintained
   ros_foxy_test_py:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_foxy_sstn3_test_004` to `0.0.3-2`:

- upstream repository: https://github.com/sstn3-ca/ros_foxy_sstn3_test_004.git
- release repository: https://github.com/sstn3-ca/ros_foxy_sstn3_test_004-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`
