### PR TITLE
ros_foxy_test_py: 0.0.3-2 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -78,7 +78,6 @@ repositories:
       url: https://github.com/ros2-gbp/ament_lint-release.git
       version: 0.9.6-1
     source:
-  #    test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_lint.git
       version: foxy
@@ -190,13 +189,16 @@ repositories:
         release: release/foxy/{package}/{version}
       url: https://github.com/sstn3-ca/ros_foxy_sstn3_test_003-release.git
       version: 0.0.4-1
-#    status: maintained
   ros_foxy_test_py:
+    doc:
+      type: git
+      url: https://github.com/udgwtest/ros_foxy_test_py.git
+      version: 0.0.3
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/sstn3-ca/ros_foxy_test_py-release-3.git
-      version: 0.0.3-1
+      url: https://github.com/udgwtest/os_foxy_test_py-release.git
+      version: 0.0.3-2
     status: maintained
   ros_workspace:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_foxy_test_py` to `0.0.3-2`:

- upstream repository: https://github.com/udgwtest/ros_foxy_test_py.git
- release repository: https://github.com/udgwtest/os_foxy_test_py-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.3-1`
