### PR TITLE
ros_foxy_test_py: 0.0.3-38 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -197,8 +197,8 @@ repositories:
     release:
       tags:
         release: release/foxy/{package}/{version}
-      url: https://github.com/udgwtest/os_foxy_test_py-release.git
-      version: 0.0.4-1
+      url: https://github.com/sstn3-ca/ros_foxy_test_py-release-3.git
+      version: 0.0.3-38
     status: maintained
   ros_workspace:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_foxy_test_py` to `0.0.3-38`:

- upstream repository: https://github.com/sstn3-ca/ros_foxy_test_py.git
- release repository: https://github.com/sstn3-ca/ros_foxy_test_py-release-3.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.4-1`
