### PR TITLE
ros_foxy_test_py: 0.0.4-37 in 'foxy/distribution.yaml' [bloom]

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -198,7 +198,7 @@ repositories:
       tags:
         release: release/foxy/{package}/{version}
       url: https://github.com/udgwtest/os_foxy_test_py-release.git
-      version: 0.0.4-1
+      version: 0.0.4-37
     status: maintained
   ros_workspace:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_foxy_test_py` to `0.0.4-37`:

- upstream repository: https://github.com/udgwtest/ros_foxy_test_py.git
- release repository: https://github.com/udgwtest/os_foxy_test_py-release.git
- distro file: `foxy/distribution.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.4-1`
